### PR TITLE
Allow for triggering idle and resume manually.

### DIFF
--- a/src/jquery.idletimeout.js
+++ b/src/jquery.idletimeout.js
@@ -49,12 +49,19 @@
 			this.resume.bind("click", function(e){
 				e.preventDefault();
 				
-				win.clearInterval(self.countdown); // stop the countdown
-				self.countdownOpen = false; // stop countdown
-				self._startTimer(); // start up the timer again
-				self._keepAlive( false ); // ping server
-				options.onResume.call( self.warning ); // call the resume callback
+				self._resume();
 			});
+		},
+
+		_resume: function() {
+			var self = this,
+				options = this.options;
+
+			win.clearInterval(self.countdown); // stop the countdown
+			self.countdownOpen = false; // stop countdown
+			self._startTimer(); // start up the timer again
+			self._keepAlive( false ); // ping server
+			options.onResume.call( self.warning ); // call the resume callback
 		},
 		
 		_idle: function(){
@@ -76,7 +83,7 @@
 					options.onTimeout.call(warning);
 				} else {
 					options.onCountdown.call(warning, counter);
-          document.title = options.titleMessage.replace('%s', counter) + self.title;
+					document.title = options.titleMessage.replace('%s', counter) + self.title;
 				}
 			}, 1000);
 		},
@@ -140,6 +147,14 @@
 		return this;
 	};
 	
+	$.idleTimeout.triggerIdle = function() {
+		idleTimeout._idle();
+	};
+
+	$.idleTimeout.triggerResume = function () {
+		idleTimeout._resume();
+	};
+
 	// options
 	$.idleTimeout.options = {
 		// number of seconds after user is idle to show the warning


### PR DESCRIPTION
I am using this plugin to manage the user session in my application, but we needed it to work across multiple tabs/windows.  Here's the scenario.  User logs in and navigates to a page in our application, and then opens a new tab for a different page in our application (e.g. a list of items for the first tab, and the detail page for a specific item as the second tab).  If the user works in the second tab for a while and doesn't return to the first one, the timeout fires on that first tab even though they're still active, logs them out after the countdown, and then the second tab behaves badly.  At best it redirects to the login page, but ajax requests from that page return strange results.

My solution was to use SignalR to communicate between windows and allow one window to cancel the countdown in another window and then start the countdown when the last window to the application has gone idle.  I had to make a small change to the plugin to allow me to do this, so that's what I'm requesting a pull for.

I'd like to package my entire solution (along with the idleTimer and idleTimeout files) and put it on NuGet, but I haven't done that before, so we'll see if I can get that to happen.
