### PR TITLE
Keepalive responsetype json added

### DIFF
--- a/src/jquery.idletimeout.js
+++ b/src/jquery.idletimeout.js
@@ -120,6 +120,8 @@
 				timeout: options.AJAXTimeout,
 				url: options.keepAliveURL,
 				type: options.AJAXPingType,
+				dataType: AJAXPingDataType,
+				data: AJAXPingData,
 				error: function(){
 					self.failedRequests--;
 				},
@@ -182,6 +184,9 @@
 
 		// send data over the AJAX keepalive if the type is POST
 		AJAXPingData: "",
+
+		// type of the data to send, defaults to json
+		AJAXPingDataType: 'json',
 		
 		// %s will be replaced by the counter value
     	titleMessage: 'Warning: %s seconds until log out | ',

--- a/src/jquery.idletimeout.js
+++ b/src/jquery.idletimeout.js
@@ -117,9 +117,9 @@
 			$.ajax({
 				timeout: options.AJAXTimeout,
 				url: options.keepAliveURL,
-				type: options.KeepalivePingType,
-				dataType: options.KeepalivePingDataType,
-				data: options.KeepalivePingData,
+				type: options.keepAlivePingType,
+				dataType: options.keepAlivePingDataType,
+				data: options.keepAlivePingData,
 				error: function(){
 					self.failedRequests--;
 				},
@@ -177,14 +177,14 @@
 		// the $.ajax timeout in MILLISECONDS!
 		AJAXTimeout: 250,
 
-		// AJAX method to ping the keepalive timeout, defaults to GET
-		KeepalivePingType: 'GET',
+		// AJAX method to ping the keepAlive timeout, defaults to GET
+		keepAlivePingType: 'GET',
 
-		// send data over the AJAX keepalive if the type is POST
-		KeepalivePingData: "",
+		// send data over the AJAX keepAlive if the type is POST
+		keepAlivePingData: "",
 
 		// type of the data to send, defaults to json
-		KeepalivePingDataType: 'json',
+		keepAlivePingDataType: 'json',
 		
 		// %s will be replaced by the counter value
     	titleMessage: 'Warning: %s seconds until log out | ',

--- a/src/jquery.idletimeout.js
+++ b/src/jquery.idletimeout.js
@@ -25,6 +25,8 @@
 			this.options = options;
 			this.countdownOpen = false;
 			this.failedRequests = options.failedRequests;
+			this.AJAXPingType = options.AJAXPingType;
+			this.AJAXPingData = options.AJAXPingData;
 			this._startTimer();
       		this.title = document.title;
 			
@@ -177,6 +179,9 @@
 
 		// AJAX method to ping the keepalive timeout, defaults to GET
 		AJAXPingType: 'GET',
+
+		// send data over the AJAX keepalive if the type is POST
+		AJAXPingData: "",
 		
 		// %s will be replaced by the counter value
     	titleMessage: 'Warning: %s seconds until log out | ',

--- a/src/jquery.idletimeout.js
+++ b/src/jquery.idletimeout.js
@@ -25,8 +25,6 @@
 			this.options = options;
 			this.countdownOpen = false;
 			this.failedRequests = options.failedRequests;
-			this.AJAXPingType = options.AJAXPingType;
-			this.AJAXPingData = options.AJAXPingData;
 			this._startTimer();
       		this.title = document.title;
 			
@@ -119,9 +117,9 @@
 			$.ajax({
 				timeout: options.AJAXTimeout,
 				url: options.keepAliveURL,
-				type: options.AJAXPingType,
-				dataType: AJAXPingDataType,
-				data: AJAXPingData,
+				type: options.KeepalivePingType,
+				dataType: options.KeepalivePingDataType,
+				data: options.KeepalivePingData,
 				error: function(){
 					self.failedRequests--;
 				},
@@ -180,13 +178,13 @@
 		AJAXTimeout: 250,
 
 		// AJAX method to ping the keepalive timeout, defaults to GET
-		AJAXPingType: 'GET',
+		KeepalivePingType: 'GET',
 
 		// send data over the AJAX keepalive if the type is POST
-		AJAXPingData: "",
+		KeepalivePingData: "",
 
 		// type of the data to send, defaults to json
-		AJAXPingDataType: 'json',
+		KeepalivePingDataType: 'json',
 		
 		// %s will be replaced by the counter value
     	titleMessage: 'Warning: %s seconds until log out | ',

--- a/src/jquery.idletimeout.js
+++ b/src/jquery.idletimeout.js
@@ -120,6 +120,8 @@
 				type: options.keepAlivePingType,
 				dataType: options.keepAlivePingDataType,
 				data: options.keepAlivePingData,
+				contentType: options.keepAliveContentType,
+				processData: options.keepAliveProcessData,
 				error: function(){
 					self.failedRequests--;
 				},
@@ -185,6 +187,12 @@
 
 		// type of the data to send, defaults to json
 		keepAlivePingDataType: 'json',
+
+		// use this type to send POST data
+		keepAliveContentType: 'application/json',
+
+		// indicate wether to process the response data
+		keepAliveProcessData: false,
 		
 		// %s will be replaced by the counter value
     	titleMessage: 'Warning: %s seconds until log out | ',

--- a/src/jquery.idletimeout.js
+++ b/src/jquery.idletimeout.js
@@ -117,6 +117,7 @@
 			$.ajax({
 				timeout: options.AJAXTimeout,
 				url: options.keepAliveURL,
+				type: options.AJAXPingType,
 				error: function(){
 					self.failedRequests--;
 				},
@@ -173,6 +174,9 @@
 		
 		// the $.ajax timeout in MILLISECONDS!
 		AJAXTimeout: 250,
+
+		// AJAX method to ping the keepalive timeout, defaults to GET
+		AJAXPingType: 'GET',
 		
 		// %s will be replaced by the counter value
     	titleMessage: 'Warning: %s seconds until log out | ',

--- a/src/jquery.idletimeout.js
+++ b/src/jquery.idletimeout.js
@@ -121,8 +121,14 @@
 					self.failedRequests--;
 				},
 				success: function(response){
-					if($.trim(response) !== options.serverResponseEquals){
-						self.failedRequests--;
+					if (options.serverResponseType === 'json') {
+						if (response.result === options.serverResponseEquals){
+							self.failedRequests--;
+						}
+					} else {
+						if($.trim(response) !== options.serverResponseEquals){
+							self.failedRequests--;
+						}
 					}
 				},
 				complete: function(){
@@ -148,6 +154,11 @@
 		// url to call to keep the session alive while the user is active
 		keepAliveURL: "",
 		
+		// the type of the server response. Can be 'string' or 'json'. 'string' default
+		// if the response from the server is 'json', use this attribute to check serverResponseEquals
+		// this checks response.result === options.serverResponseEquals
+		serverResponseType: "json",
+				
 		// the response from keepAliveURL must equal this text:
 		serverResponseEquals: "OK",
 		


### PR DESCRIPTION
In this usecase the keepalive webservice can deal with a webservice that responds with a json message on a GET request. This response is always of the form:
{
   "id": integer,
   "result": String
}

Added the possibility to switch to using the json response. This message should contain a 'result' with the
serverResponseEquals string. So in this case the "result" will be "OK", like this:
{
   "id": 2,
   "result": "OK"
}
